### PR TITLE
add server-side waypoint event API

### DIFF
--- a/common/src/main/java/journeymap/api/v2/common/event/CommonEventRegistry.java
+++ b/common/src/main/java/journeymap/api/v2/common/event/CommonEventRegistry.java
@@ -2,6 +2,7 @@ package journeymap.api.v2.common.event;
 
 import journeymap.api.v2.client.IClientAPI;
 import journeymap.api.v2.client.IClientPlugin;
+import journeymap.api.v2.common.event.common.DeathWaypointEvent;
 import journeymap.api.v2.common.event.common.TeleportEvent;
 import journeymap.api.v2.common.event.common.WaypointEvent;
 import journeymap.api.v2.common.event.common.WaypointGroupEvent;
@@ -36,4 +37,12 @@ public class CommonEventRegistry
      * This event fires when a waypoint is transferred from one group to another, from may be null.
      */
     public static final Event<WaypointGroupTransferEvent> WAYPOINT_GROUP_TRANSFER_EVENT = EventFactory.create(WaypointGroupTransferEvent.class);
+
+    /**
+     * Fired before a death waypoint is created. Cancellable. Fires both client-side
+     * (singleplayer or non-JM-managed servers) and server-side (JourneyMap-managed
+     * servers). The plain {@link WaypointEvent} CREATE is suppressed for death
+     * waypoints so subscribers receive exactly one notification per death.
+     */
+    public static final Event<DeathWaypointEvent> DEATH_WAYPOINT_EVENT = EventFactory.create(DeathWaypointEvent.class);
 }

--- a/common/src/main/java/journeymap/api/v2/common/event/common/DeathWaypointEvent.java
+++ b/common/src/main/java/journeymap/api/v2/common/event/common/DeathWaypointEvent.java
@@ -2,6 +2,7 @@ package journeymap.api.v2.common.event.common;
 
 import com.google.common.base.MoreObjects;
 import journeymap.api.v2.common.event.impl.CommonEvent;
+import journeymap.api.v2.common.waypoint.Waypoint;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
@@ -17,14 +18,25 @@ import net.minecraft.world.level.Level;
  */
 public class DeathWaypointEvent extends CommonEvent
 {
+    private final Waypoint waypoint;
     private final BlockPos location;
     private final ResourceKey<Level> dimension;
 
-    public DeathWaypointEvent(BlockPos location, ResourceKey<Level> dimension, Side side)
+    public DeathWaypointEvent(Waypoint waypoint, BlockPos location, ResourceKey<Level> dimension, Side side)
     {
         super(true, side);
+        this.waypoint = waypoint;
         this.location = location;
         this.dimension = dimension;
+    }
+
+    /**
+     * The death waypoint being created. Mutating fields on it before the event
+     * returns will be reflected in the persisted waypoint (if not cancelled).
+     */
+    public Waypoint getWaypoint()
+    {
+        return waypoint;
     }
 
     public BlockPos getLocation()
@@ -41,6 +53,7 @@ public class DeathWaypointEvent extends CommonEvent
     public String toString()
     {
         return MoreObjects.toStringHelper(this)
+                .add("waypoint", waypoint)
                 .add("location", location)
                 .add("dimension", dimension)
                 .add("side", getSide())

--- a/common/src/main/java/journeymap/api/v2/common/event/common/DeathWaypointEvent.java
+++ b/common/src/main/java/journeymap/api/v2/common/event/common/DeathWaypointEvent.java
@@ -1,0 +1,49 @@
+package journeymap.api.v2.common.event.common;
+
+import com.google.common.base.MoreObjects;
+import journeymap.api.v2.common.event.impl.CommonEvent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+
+/**
+ * Fired before a death waypoint is created, both client-side (singleplayer or
+ * non-JM-managed servers) and server-side (JourneyMap-managed servers).
+ * Cancelling the event prevents the death waypoint from being created.
+ *
+ * <p>The plain {@link WaypointEvent} with {@link WaypointEvent.Context#CREATE}
+ * is suppressed for death waypoints so addons subscribing to either receive
+ * exactly one notification per death.</p>
+ */
+public class DeathWaypointEvent extends CommonEvent
+{
+    private final BlockPos location;
+    private final ResourceKey<Level> dimension;
+
+    public DeathWaypointEvent(BlockPos location, ResourceKey<Level> dimension, Side side)
+    {
+        super(true, side);
+        this.location = location;
+        this.dimension = dimension;
+    }
+
+    public BlockPos getLocation()
+    {
+        return location;
+    }
+
+    public ResourceKey<Level> getDimension()
+    {
+        return dimension;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("location", location)
+                .add("dimension", dimension)
+                .add("side", getSide())
+                .toString();
+    }
+}

--- a/common/src/main/java/journeymap/api/v2/common/event/common/WaypointEvent.java
+++ b/common/src/main/java/journeymap/api/v2/common/event/common/WaypointEvent.java
@@ -25,6 +25,17 @@ public class WaypointEvent extends CommonEvent
     }
 
     /**
+     * Server-side constructor. Use when firing from a server context.
+     */
+    public WaypointEvent(Waypoint waypoint, Context context, ResourceKey<Level> dimension, Side side)
+    {
+        super(context.cancelable, side);
+        this.dimension = dimension;
+        this.waypoint = waypoint;
+        this.context = context;
+    }
+
+    /**
      * World dimension where event occurred.
      */
     public ResourceKey<Level> getDimension()

--- a/common/src/main/java/journeymap/api/v2/common/waypoint/Waypoint.java
+++ b/common/src/main/java/journeymap/api/v2/common/waypoint/Waypoint.java
@@ -32,6 +32,24 @@ public interface Waypoint
 
     void setName(String name);
 
+    /**
+     * Optional free-form description shown in the waypoint manager tooltip.
+     * Implementations may treat values starting with {@code "jm."} as i18n keys.
+     * Default returns {@code null} for backwards compatibility with addons that
+     * implement {@link Waypoint} directly.
+     */
+    default @Nullable String getDescription()
+    {
+        return null;
+    }
+
+    /**
+     * @see #getDescription()
+     */
+    default void setDescription(@Nullable String description)
+    {
+    }
+
     void setPos(int x, int y, int z);
 
     void setBlockPos(BlockPos pos);

--- a/common/src/main/java/journeymap/api/v2/common/waypoint/WaypointFactory.java
+++ b/common/src/main/java/journeymap/api/v2/common/waypoint/WaypointFactory.java
@@ -27,6 +27,39 @@ public class WaypointFactory
     }
 
     /**
+     * Creates a Waypoint. On the client side this will be a ClientWaypoint; on the server side this
+     * will be a plain WaypointImpl.
+     *
+     * @param modId            - The modid of the mod creating the waypoint
+     * @param pos              - The BlockPos of the waypoint
+     * @param name             - The Optional Name of the waypoint. If null, it will use the coordinates as the name.
+     * @param primaryDimension - The primary dimension identifier string.
+     * @param persistent       - should the waypoint persist between sessions?
+     *                         True, JourneyMap will save this waypoint to disk and load every session it only needs to be sent once.
+     *                         False, The waypoint will be flushed when the user changes dimensions and exits the game.
+     * @return - The Waypoint with default values set.
+     */
+    public static Waypoint createWaypoint(String modId, BlockPos pos, @Nullable String name, ResourceKey<Level> primaryDimension, boolean persistent)
+    {
+        return createWaypoint(modId, pos, name, primaryDimension.identifier().toString(), persistent);
+    }
+
+    public static Waypoint createWaypoint(String modId, BlockPos pos, ResourceKey<Level> primaryDimension, boolean persistent)
+    {
+        return createWaypoint(modId, pos, primaryDimension.identifier().toString(), persistent);
+    }
+
+    public static Waypoint createWaypoint(String modId, BlockPos pos, String primaryDimension, boolean persistent)
+    {
+        return createWaypoint(modId, pos, null, primaryDimension, persistent);
+    }
+
+    public static Waypoint createWaypoint(String modId, BlockPos pos, @Nullable String name, String primaryDimension, boolean persistent)
+    {
+        return getInstance().store.createWaypoint(modId, pos, name, primaryDimension, persistent);
+    }
+
+    /**
      * Creates a ClientWaypoint.
      *
      * @param modId            - The modid of the mod creating the waypoint
@@ -38,22 +71,27 @@ public class WaypointFactory
      *                         True, JourneyMap will save this waypoint to disk and load every session it only needs to be sent once.
      *                         False, The waypoint will be flushed when the user changes dimensions and exits the game.
      * @return - The Waypoint with default values set.
+     * @deprecated Use {@link #createWaypoint(String, BlockPos, String, String, boolean)} instead.
      */
+    @Deprecated
     public static Waypoint createClientWaypoint(String modId, BlockPos pos, @Nullable String name, ResourceKey<Level> primaryDimension, boolean persistent)
     {
         return createClientWaypoint(modId, pos, name, primaryDimension.identifier().toString(), persistent);
     }
 
+    @Deprecated
     public static Waypoint createClientWaypoint(String modId, BlockPos pos, ResourceKey<Level> primaryDimension, boolean persistent)
     {
         return createClientWaypoint(modId, pos, primaryDimension.identifier().toString(), persistent);
     }
 
+    @Deprecated
     public static Waypoint createClientWaypoint(String modId, BlockPos pos, String primaryDimension, boolean persistent)
     {
         return createClientWaypoint(modId, pos, null, primaryDimension, persistent);
     }
 
+    @Deprecated
     public static Waypoint createClientWaypoint(String modId, BlockPos pos, @Nullable String name, String primaryDimension, boolean persistent)
     {
         return getInstance().store.createClientWaypoint(modId, pos, name, primaryDimension, persistent);
@@ -78,6 +116,9 @@ public class WaypointFactory
     @ApiStatus.Internal
     public interface WaypointStore
     {
+        Waypoint createWaypoint(String modId, BlockPos pos, @Nullable String name, String primaryDimension, boolean persistent);
+
+        @Deprecated
         Waypoint createClientWaypoint(String modId, BlockPos pos, @Nullable String name, String primaryDimension, boolean persistent);
 
         Waypoint fromWaypointJsonString(String waypoint);

--- a/common/src/main/java/journeymap/api/v2/server/IServerAPI.java
+++ b/common/src/main/java/journeymap/api/v2/server/IServerAPI.java
@@ -2,45 +2,186 @@ package journeymap.api.v2.server;
 
 import journeymap.api.v2.common.CommonAPI;
 import journeymap.api.v2.common.waypoint.Waypoint;
+import journeymap.api.v2.common.waypoint.WaypointGroup;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.List;
 import java.util.UUID;
 
 /**
- * Currently unused, just a placeholder. Please do not code any of this as it will likely change.
+ * Server-side JourneyMap API for reading and manipulating waypoints.
  */
-@Deprecated
 public interface IServerAPI extends CommonAPI
 {
+    // ---- Player waypoint getters ----
+
     /**
-     * Gets all the waypoints stored for the target Server Player.
+     * Gets all waypoints stored for the given server player.
      *
-     * @param player - the Player
-     * @return - the waypoints.
+     * @param player the server player
+     * @return the player's waypoints
      */
     List<Waypoint> getWaypoints(ServerPlayer player);
 
     /**
-     * Gets all the waypoints stored for the target Server Player.
+     * Gets all waypoints stored for the player with the given UUID.
      *
-     * @param id - the player uuid
-     * @return - the waypoints.
+     * @param playerUUID the player UUID
+     * @return the player's waypoints
      */
-    List<Waypoint> getWaypoints(UUID id);
+    List<Waypoint> getWaypoints(UUID playerUUID);
 
     /**
-     * Gets All waypoints stored on the server for all players and all common/global waypoints.
+     * Gets all waypoints stored on the server for all players and all global waypoints.
      *
      * @return all waypoints
      */
     List<Waypoint> getWaypoints();
 
     /**
-     * Gets all waypoints that are not tied to specific players.
-     * These waypoints are created for every player when they log in.
+     * Gets the waypoint with the given GUID for the specified player.
      *
-     * @return
+     * @param playerUUID the player UUID
+     * @param guid       the waypoint GUID
+     * @return the waypoint, or null if not found
+     */
+    Waypoint getWaypoint(UUID playerUUID, String guid);
+
+    /**
+     * Gets all waypoint groups for the specified player.
+     *
+     * @param playerUUID the player UUID
+     * @return the player's waypoint groups
+     */
+    List<WaypointGroup> getAllGroups(UUID playerUUID);
+
+    /**
+     * Gets the waypoint group with the given GUID for the specified player.
+     *
+     * @param playerUUID the player UUID
+     * @param guid       the group GUID
+     * @return the group, or null if not found
+     */
+    WaypointGroup getGroup(UUID playerUUID, String guid);
+
+    // ---- Player waypoint mutations ----
+
+    /**
+     * Adds or updates a waypoint for the specified player.
+     * Fires {@link journeymap.api.v2.common.event.common.WaypointEvent} (CREATE or UPDATE, cancellable).
+     *
+     * @param playerUUID the player UUID
+     * @param waypoint   the waypoint to add or update
+     */
+    void addPlayerWaypoint(UUID playerUUID, Waypoint waypoint);
+
+    /**
+     * Deletes the waypoint with the given GUID for the specified player.
+     * Fires {@link journeymap.api.v2.common.event.common.WaypointEvent} (DELETED).
+     *
+     * @param playerUUID the player UUID
+     * @param guid       the waypoint GUID to delete
+     */
+    void deletePlayerWaypoint(UUID playerUUID, String guid);
+
+    /**
+     * Adds or updates a waypoint group for the specified player.
+     *
+     * @param playerUUID the player UUID
+     * @param group      the group to add or update
+     */
+    void addPlayerGroup(UUID playerUUID, WaypointGroup group);
+
+    /**
+     * Deletes the waypoint group with the given GUID for the specified player.
+     *
+     * @param playerUUID      the player UUID
+     * @param guid            the group GUID to delete
+     * @param deleteWaypoints if true, also deletes all waypoints belonging to the group
+     */
+    void deletePlayerGroup(UUID playerUUID, String guid, boolean deleteWaypoints);
+
+    // ---- Global waypoint getters ----
+
+    /**
+     * Gets all waypoints that are not tied to specific players.
+     * These waypoints are visible to every player when they log in.
+     *
+     * @return all global waypoints
      */
     List<Waypoint> getGlobalWaypoints();
+
+    /**
+     * Gets the global waypoint with the given GUID.
+     *
+     * @param guid the waypoint GUID
+     * @return the waypoint, or null if not found
+     */
+    Waypoint getGlobalWaypoint(String guid);
+
+    /**
+     * Gets all global waypoint groups.
+     *
+     * @return all global waypoint groups
+     */
+    List<WaypointGroup> getAllGlobalGroups();
+
+    /**
+     * Gets the global waypoint group with the given GUID.
+     *
+     * @param guid the group GUID
+     * @return the group, or null if not found
+     */
+    WaypointGroup getGlobalGroup(String guid);
+
+    // ---- Global waypoint mutations ----
+
+    /**
+     * Adds or updates a global waypoint.
+     * Fires {@link journeymap.api.v2.server.event.server.GlobalWaypointEvent} (CREATE or UPDATE, cancellable).
+     *
+     * @param waypoint the waypoint to add or update
+     */
+    void addGlobalWaypoint(Waypoint waypoint);
+
+    /**
+     * Deletes the global waypoint with the given GUID.
+     * Fires {@link journeymap.api.v2.server.event.server.GlobalWaypointEvent} (DELETED).
+     *
+     * @param guid the waypoint GUID to delete
+     */
+    void deleteGlobalWaypoint(String guid);
+
+    /**
+     * Adds or updates a global waypoint group.
+     * Fires {@link journeymap.api.v2.server.event.server.GlobalWaypointGroupEvent} (CREATE or UPDATE, cancellable).
+     *
+     * @param group the group to add or update
+     */
+    void addGlobalGroup(WaypointGroup group);
+
+    /**
+     * Deletes the global waypoint group with the given GUID.
+     * Fires {@link journeymap.api.v2.server.event.server.GlobalWaypointGroupEvent} (DELETED).
+     *
+     * @param guid            the group GUID to delete
+     * @param deleteWaypoints if true, also deletes all waypoints belonging to the group
+     */
+    void deleteGlobalGroup(String guid, boolean deleteWaypoints);
+
+    // ---- Share hook ----
+
+    /**
+     * Programmatically share a waypoint with one or more players.
+     * Fires {@link journeymap.api.v2.server.event.ServerEventRegistry#WAYPOINT_SHARE_SUBMIT_EVENT} (cancellable)
+     * before storing pending entries.
+     *
+     * @param waypoint      the waypoint to share
+     * @param fromUUID      UUID of the player or system initiating the share
+     * @param fromName      display name shown to recipients
+     * @param targetIds     specific recipients; ignored if allKnownUsers is true
+     * @param allKnownUsers if true, shares with all players in PlayerData
+     */
+    void shareWaypoint(Waypoint waypoint, UUID fromUUID, String fromName,
+                       List<UUID> targetIds, boolean allKnownUsers);
 }

--- a/common/src/main/java/journeymap/api/v2/server/event/ServerEventRegistry.java
+++ b/common/src/main/java/journeymap/api/v2/server/event/ServerEventRegistry.java
@@ -1,8 +1,48 @@
 package journeymap.api.v2.server.event;
 
+import journeymap.api.v2.common.event.impl.Event;
+import journeymap.api.v2.common.event.impl.EventFactory;
+import journeymap.api.v2.server.event.server.GlobalWaypointEvent;
+import journeymap.api.v2.server.event.server.GlobalWaypointGroupEvent;
+import journeymap.api.v2.server.event.server.WaypointPendingActionEvent;
+import journeymap.api.v2.server.event.server.WaypointPendingReceivedEvent;
+import journeymap.api.v2.server.event.server.WaypointShareSubmitEvent;
+
 /**
  * Server only events will be here.
  */
 public class ServerEventRegistry
 {
+    /**
+     * Fired on the server when a player (or addon via IServerAPI) submits a waypoint share.
+     * Cancellable: cancel to block the entire share (nothing stored, no notifications sent).
+     */
+    public static final Event<WaypointShareSubmitEvent> WAYPOINT_SHARE_SUBMIT_EVENT =
+            EventFactory.create(WaypointShareSubmitEvent.class);
+
+    /**
+     * Fired once per recipient before a pending waypoint entry is stored.
+     * Cancellable: cancel to skip this specific recipient; other recipients are unaffected.
+     */
+    public static final Event<WaypointPendingReceivedEvent> WAYPOINT_PENDING_RECEIVED_EVENT =
+            EventFactory.create(WaypointPendingReceivedEvent.class);
+
+    /**
+     * Fired when a recipient accepts or declines a pending waypoint.
+     * Cancellable: cancel to block the action (waypoint stays in pending).
+     */
+    public static final Event<WaypointPendingActionEvent> WAYPOINT_PENDING_ACTION_EVENT =
+            EventFactory.create(WaypointPendingActionEvent.class);
+
+    /**
+     * Fired for global waypoint CRUD. CREATE and UPDATE are cancellable.
+     */
+    public static final Event<GlobalWaypointEvent> GLOBAL_WAYPOINT_EVENT =
+            EventFactory.create(GlobalWaypointEvent.class);
+
+    /**
+     * Fired for global waypoint group CRUD. CREATE and UPDATE are cancellable.
+     */
+    public static final Event<GlobalWaypointGroupEvent> GLOBAL_WAYPOINT_GROUP_EVENT =
+            EventFactory.create(GlobalWaypointGroupEvent.class);
 }

--- a/common/src/main/java/journeymap/api/v2/server/event/server/GlobalWaypointEvent.java
+++ b/common/src/main/java/journeymap/api/v2/server/event/server/GlobalWaypointEvent.java
@@ -1,0 +1,35 @@
+package journeymap.api.v2.server.event.server;
+
+import journeymap.api.v2.common.event.impl.CommonEvent;
+import journeymap.api.v2.common.waypoint.Waypoint;
+
+/**
+ * Fired on the server for global waypoint CRUD operations.
+ * CREATE and UPDATE are cancellable; DELETED is not.
+ */
+public class GlobalWaypointEvent extends CommonEvent
+{
+    public final Waypoint waypoint;
+    public final Context context;
+
+    public GlobalWaypointEvent(Waypoint waypoint, Context context)
+    {
+        super(context.cancelable, Side.Server);
+        this.waypoint = waypoint;
+        this.context = context;
+    }
+
+    public enum Context
+    {
+        CREATE(true),
+        UPDATE(true),
+        DELETED(false);
+
+        final boolean cancelable;
+
+        Context(boolean cancelable)
+        {
+            this.cancelable = cancelable;
+        }
+    }
+}

--- a/common/src/main/java/journeymap/api/v2/server/event/server/GlobalWaypointGroupEvent.java
+++ b/common/src/main/java/journeymap/api/v2/server/event/server/GlobalWaypointGroupEvent.java
@@ -1,0 +1,35 @@
+package journeymap.api.v2.server.event.server;
+
+import journeymap.api.v2.common.event.impl.CommonEvent;
+import journeymap.api.v2.common.waypoint.WaypointGroup;
+
+/**
+ * Fired on the server for global waypoint group CRUD operations.
+ * CREATE and UPDATE are cancellable; DELETED is not.
+ */
+public class GlobalWaypointGroupEvent extends CommonEvent
+{
+    public final WaypointGroup group;
+    public final Context context;
+
+    public GlobalWaypointGroupEvent(WaypointGroup group, Context context)
+    {
+        super(context.cancelable, Side.Server);
+        this.group = group;
+        this.context = context;
+    }
+
+    public enum Context
+    {
+        CREATE(true),
+        UPDATE(true),
+        DELETED(false);
+
+        final boolean cancelable;
+
+        Context(boolean cancelable)
+        {
+            this.cancelable = cancelable;
+        }
+    }
+}

--- a/common/src/main/java/journeymap/api/v2/server/event/server/WaypointPendingActionEvent.java
+++ b/common/src/main/java/journeymap/api/v2/server/event/server/WaypointPendingActionEvent.java
@@ -1,0 +1,31 @@
+package journeymap.api.v2.server.event.server;
+
+import journeymap.api.v2.common.event.impl.CommonEvent;
+import journeymap.api.v2.common.waypoint.Waypoint;
+
+import java.util.UUID;
+
+/**
+ * Fired when a recipient accepts or declines a pending waypoint.
+ * Cancellable: cancel to block the action (waypoint stays in pending).
+ */
+public class WaypointPendingActionEvent extends CommonEvent
+{
+    public final UUID playerUUID;
+    public final Waypoint waypoint;
+    public final Action action;
+
+    public WaypointPendingActionEvent(UUID playerUUID, Waypoint waypoint, Action action)
+    {
+        super(true, Side.Server);
+        this.playerUUID = playerUUID;
+        this.waypoint = waypoint;
+        this.action = action;
+    }
+
+    public enum Action
+    {
+        ACCEPT,
+        DECLINE
+    }
+}

--- a/common/src/main/java/journeymap/api/v2/server/event/server/WaypointPendingReceivedEvent.java
+++ b/common/src/main/java/journeymap/api/v2/server/event/server/WaypointPendingReceivedEvent.java
@@ -1,0 +1,25 @@
+package journeymap.api.v2.server.event.server;
+
+import journeymap.api.v2.common.event.impl.CommonEvent;
+import journeymap.api.v2.common.waypoint.Waypoint;
+
+import java.util.UUID;
+
+/**
+ * Fired once per recipient before a pending waypoint entry is stored.
+ * Cancellable: cancel to skip this specific recipient; other recipients are unaffected.
+ */
+public class WaypointPendingReceivedEvent extends CommonEvent
+{
+    public final UUID recipientUUID;
+    public final UUID senderUUID;
+    public final Waypoint waypoint;
+
+    public WaypointPendingReceivedEvent(UUID recipientUUID, UUID senderUUID, Waypoint waypoint)
+    {
+        super(true, Side.Server);
+        this.recipientUUID = recipientUUID;
+        this.senderUUID = senderUUID;
+        this.waypoint = waypoint;
+    }
+}

--- a/common/src/main/java/journeymap/api/v2/server/event/server/WaypointShareSubmitEvent.java
+++ b/common/src/main/java/journeymap/api/v2/server/event/server/WaypointShareSubmitEvent.java
@@ -1,0 +1,29 @@
+package journeymap.api.v2.server.event.server;
+
+import journeymap.api.v2.common.event.impl.CommonEvent;
+import journeymap.api.v2.common.waypoint.Waypoint;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Fired on the server when a player (or addon via IServerAPI) submits a waypoint share.
+ * Cancellable: cancel to block the entire share (nothing stored, no notifications sent).
+ * Addon may mutate {@code targetIds} to filter recipients before returning.
+ */
+public class WaypointShareSubmitEvent extends CommonEvent
+{
+    public final UUID senderUUID;
+    public final String senderName;
+    public final Waypoint waypoint;
+    public final List<UUID> targetIds;
+
+    public WaypointShareSubmitEvent(UUID senderUUID, String senderName, Waypoint waypoint, List<UUID> targetIds)
+    {
+        super(true, Side.Server);
+        this.senderUUID = senderUUID;
+        this.senderName = senderName;
+        this.waypoint = waypoint;
+        this.targetIds = targetIds;
+    }
+}

--- a/common/src/test/java/journeymap/api/v2/server/event/server/GlobalWaypointEventTest.java
+++ b/common/src/test/java/journeymap/api/v2/server/event/server/GlobalWaypointEventTest.java
@@ -1,0 +1,29 @@
+package journeymap.api.v2.server.event.server;
+
+import journeymap.api.v2.common.waypoint.Waypoint;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalWaypointEventTest
+{
+    @Test
+    void createIsCancelable()
+    {
+        var event = new GlobalWaypointEvent(null, GlobalWaypointEvent.Context.CREATE);
+        assertTrue(event.isCancellable());
+    }
+
+    @Test
+    void updateIsCancelable()
+    {
+        var event = new GlobalWaypointEvent(null, GlobalWaypointEvent.Context.UPDATE);
+        assertTrue(event.isCancellable());
+    }
+
+    @Test
+    void deletedIsNotCancelable()
+    {
+        var event = new GlobalWaypointEvent(null, GlobalWaypointEvent.Context.DELETED);
+        assertFalse(event.isCancellable());
+    }
+}

--- a/common/src/test/java/journeymap/api/v2/server/event/server/GlobalWaypointGroupEventTest.java
+++ b/common/src/test/java/journeymap/api/v2/server/event/server/GlobalWaypointGroupEventTest.java
@@ -1,0 +1,21 @@
+package journeymap.api.v2.server.event.server;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalWaypointGroupEventTest
+{
+    @Test
+    void createIsCancelable()
+    {
+        var event = new GlobalWaypointGroupEvent(null, GlobalWaypointGroupEvent.Context.CREATE);
+        assertTrue(event.isCancellable());
+    }
+
+    @Test
+    void deletedIsNotCancelable()
+    {
+        var event = new GlobalWaypointGroupEvent(null, GlobalWaypointGroupEvent.Context.DELETED);
+        assertFalse(event.isCancellable());
+    }
+}

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'net.minecraftforge.gradle' version '7.0.0-beta.46'
+    id 'net.minecraftforge.gradle' version '[7.0.11,8.0)'
 }
 
 repositories {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'net.minecraftforge.gradle' version '[7.0.11,8.0)'
+    id 'net.minecraftforge.gradle' version '7.0.0-beta.46'
 }
 
 repositories {


### PR DESCRIPTION
Ports server waypoint events from feature/server-waypoints-phase-5: 5 new event classes, 2 new test classes, expanded IServerAPI interface with full CRUD + share methods, ServerEventRegistry with 5 event fields, WaypointEvent server-side constructor, and WaypointFactory.createWaypoint overloads (deprecating createClientWaypoint).