### PR TITLE
fix: classifyAndGroup pairs a hole with the wrong hull

### DIFF
--- a/common/src/main/java/journeymap/api/v2/client/util/PolygonHelper.java
+++ b/common/src/main/java/journeymap/api/v2/client/util/PolygonHelper.java
@@ -206,6 +206,14 @@ public class PolygonHelper
      * <p>
      * Assumes that hulls use CCW point winding and holes use CW point winding, which seems to be
      * consistent with {@link #createPolygonFromArea}.
+     * <p>
+     * Each hole is grouped with the innermost hull that fully contains it.  A hole that no hull
+     * contains but that intersects one or more hulls (possible only for arbitrary input, not for
+     * the normalized {@link Area} contours {@link #createPolygonFromArea} emits) falls back to the
+     * first hull it intersects; a hole that touches no hull is dropped.  The innermost-owner
+     * result is independent of contour order when the hulls strictly nest, as they do for
+     * normalized {@code Area} contours; for overlapping or equal-area hulls that both contain a
+     * hole the first candidate wins.
      *
      * @param polygons The input list of {@link MapPolygon}s.
      * @return The resulting list of {@link MapPolygonWithHoles}.
@@ -235,40 +243,46 @@ public class PolygonHelper
                 .collect(Collectors.toList());
 
         final List<List<MapPolygon>> hullHoles = new ArrayList<>();
-        for (int index = 0; index < hulls.size(); ++index)
-        {
-            hullHoles.add(new ArrayList<>());
-        }
+        hulls.forEach(hull -> hullHoles.add(new ArrayList<>()));
 
         for (final MapPolygon hole : holes)
         {
             final Area holeArea = toArea(hole);
             int owner = -1;
             long ownerArea = Long.MAX_VALUE;
+            int fallback = -1;
 
-            // A hole is carved from the innermost hull that fully contains it.  Containing
-            // hulls are nested, so the one with the smallest ring area is the immediate
-            // owner.  Nested hulls differ in area, so this pairing is independent of the
-            // contour order.
+            // A hole is carved from the innermost hull that fully contains it: containing hulls
+            // nest, so the smallest by ring area is the immediate owner.  For the normalized Area
+            // contours createPolygonFromArea emits, nested hulls differ in area and this pairing
+            // is independent of the contour order; for arbitrary input with overlapping or
+            // equal-area hulls that both contain the hole, the first candidate wins.
             for (int index = 0; index < hullAreas.size(); ++index)
             {
-                if (!contains(hullAreas.get(index).getB(), holeArea))
+                final Area hullArea = hullAreas.get(index).getB();
+                if (contains(hullArea, holeArea))
                 {
-                    continue;
+                    final long area = ringArea(hullAreas.get(index).getA());
+                    if (owner < 0 || area < ownerArea)
+                    {
+                        owner = index;
+                        ownerArea = area;
+                    }
                 }
-                final long area = ringArea(hullAreas.get(index).getA());
-                if (owner < 0 || area < ownerArea)
+                else if (fallback < 0 && intersects(hullArea, holeArea))
                 {
-                    owner = index;
-                    ownerArea = area;
+                    fallback = index;
                 }
             }
 
-            // Malformed input can leave a hole with no containing hull; drop it rather
-            // than forcing it onto an unrelated hull.
-            if (owner >= 0)
+            // Prefer the innermost containing hull.  A hole that no hull contains but that
+            // intersects one (possible only for arbitrary, non-normalized input) keeps the
+            // pre-fix behavior of grouping with the first hull it intersects; a hole that
+            // touches no hull is dropped rather than forced onto an unrelated hull.
+            final int target = owner >= 0 ? owner : fallback;
+            if (target >= 0)
             {
-                hullHoles.get(owner).add(hole);
+                hullHoles.get(target).add(hole);
             }
         }
 
@@ -299,15 +313,31 @@ public class PolygonHelper
     }
 
     /**
-     * Twice the unsigned area enclosed by the polygon ring, via the shoelace formula.
-     * Only used to rank containing hulls by size, so the constant factor of two is
-     * irrelevant.
+     * Determines whether the filled {@code hull} and {@code hole} areas overlap at all.  Used only
+     * as the fallback association for an arbitrary-input hole that no hull fully contains.
+     *
+     * @param hull The candidate hull area.
+     * @param hole The hole area.
+     * @return True if the two areas intersect.
+     */
+    private static boolean intersects(@Nonnull final Area hull, @Nonnull final Area hole)
+    {
+        final Area intersection = new Area(hull);
+        intersection.intersect(hole);
+        return !intersection.isEmpty();
+    }
+
+    /**
+     * Twice the signed area enclosed by the polygon ring, via the shoelace formula.  The sign
+     * encodes winding (negative for the clockwise winding a hole uses) and the magnitude is twice
+     * the enclosed area; the constant factor of two is irrelevant to both callers.
      *
      * @param polygon The polygon.
-     * @return Twice the unsigned enclosed area.
+     * @return Twice the signed enclosed area.
      */
-    private static long ringArea(@Nonnull final MapPolygon polygon)
+    private static long signedRingArea(@Nonnull final MapPolygon polygon)
     {
+        // from https://stackoverflow.com/a/18472899/43534
         long sum = 0;
         final List<BlockPos> points = polygon.getPoints();
         BlockPos a = points.get(points.size() - 1);
@@ -316,7 +346,18 @@ public class PolygonHelper
             sum += (long) (b.getX() - a.getX()) * (b.getZ() + a.getZ());
             a = b;
         }
-        return Math.abs(sum);
+        return sum;
+    }
+
+    /**
+     * Twice the unsigned area enclosed by the polygon ring, used to rank containing hulls by size.
+     *
+     * @param polygon The polygon.
+     * @return Twice the unsigned enclosed area.
+     */
+    private static long ringArea(@Nonnull final MapPolygon polygon)
+    {
+        return Math.abs(signedRingArea(polygon));
     }
 
     /**
@@ -368,15 +409,6 @@ public class PolygonHelper
      */
     private static boolean isHole(@Nonnull final MapPolygon polygon)
     {
-        // from https://stackoverflow.com/a/18472899/43534
-        long sum = 0;
-        final List<BlockPos> points = polygon.getPoints();
-        BlockPos a = points.get(points.size() - 1);
-        for (final BlockPos b : points)
-        {
-            sum += (long) (b.getX() - a.getX()) * (b.getZ() + a.getZ());
-            a = b;
-        }
-        return sum < 0;
+        return signedRingArea(polygon) < 0;
     }
 }

--- a/common/src/main/java/journeymap/api/v2/client/util/PolygonHelper.java
+++ b/common/src/main/java/journeymap/api/v2/client/util/PolygonHelper.java
@@ -33,7 +33,6 @@ import java.awt.geom.Area;
 import java.awt.geom.PathIterator;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -229,32 +228,95 @@ public class PolygonHelper
             }
         }
 
-        final List<Tuple<MapPolygon, Area>> holeAreas = holes.stream()
-                .map(hole -> new Tuple<>(hole, toArea(hole)))
+        // Pair each hull with its filled area (nesting ignored) so a hole can be tested
+        // for containment against it.
+        final List<Tuple<MapPolygon, Area>> hullAreas = hulls.stream()
+                .map(hull -> new Tuple<>(hull, toArea(hull)))
                 .collect(Collectors.toList());
 
-        final List<MapPolygonWithHoles> result = new ArrayList<>();
-        for (final MapPolygon hull : hulls)
+        final List<List<MapPolygon>> hullHoles = new ArrayList<>();
+        for (int index = 0; index < hulls.size(); ++index)
         {
-            final Area hullArea = toArea(hull);
-            final List<MapPolygon> hullHoles = new ArrayList<>();
+            hullHoles.add(new ArrayList<>());
+        }
 
-            for (final Iterator<Tuple<MapPolygon, Area>> iterator = holeAreas.iterator(); iterator.hasNext(); )
+        for (final MapPolygon hole : holes)
+        {
+            final Area holeArea = toArea(hole);
+            int owner = -1;
+            long ownerArea = Long.MAX_VALUE;
+
+            // A hole is carved from the innermost hull that fully contains it.  Containing
+            // hulls are nested, so the one with the smallest ring area is the immediate
+            // owner.  Nested hulls differ in area, so this pairing is independent of the
+            // contour order.
+            for (int index = 0; index < hullAreas.size(); ++index)
             {
-                final Tuple<MapPolygon, Area> holeArea = iterator.next();
-                final Area intersection = new Area(hullArea);
-                intersection.intersect(holeArea.getB());
-                if (!intersection.isEmpty())
+                if (!contains(hullAreas.get(index).getB(), holeArea))
                 {
-                    hullHoles.add(holeArea.getA());
-                    iterator.remove();
+                    continue;
+                }
+                final long area = ringArea(hullAreas.get(index).getA());
+                if (owner < 0 || area < ownerArea)
+                {
+                    owner = index;
+                    ownerArea = area;
                 }
             }
 
-            result.add(new MapPolygonWithHoles(hull, hullHoles));
+            // Malformed input can leave a hole with no containing hull; drop it rather
+            // than forcing it onto an unrelated hull.
+            if (owner >= 0)
+            {
+                hullHoles.get(owner).add(hole);
+            }
+        }
+
+        final List<MapPolygonWithHoles> result = new ArrayList<>();
+        for (int index = 0; index < hulls.size(); ++index)
+        {
+            result.add(new MapPolygonWithHoles(hulls.get(index), hullHoles.get(index)));
         }
 
         return result;
+    }
+
+    /**
+     * Determines whether the filled {@code hull} area fully contains the filled
+     * {@code hole} area, i.e. the hole lies entirely inside the hull.  This is
+     * stronger than a mere intersection: an island hull sitting inside a hole
+     * intersects that hole without containing it.
+     *
+     * @param hull The candidate containing area.
+     * @param hole The hole area.
+     * @return True if the hole is fully contained by the hull.
+     */
+    private static boolean contains(@Nonnull final Area hull, @Nonnull final Area hole)
+    {
+        final Area remainder = new Area(hole);
+        remainder.subtract(hull);
+        return remainder.isEmpty();
+    }
+
+    /**
+     * Twice the unsigned area enclosed by the polygon ring, via the shoelace formula.
+     * Only used to rank containing hulls by size, so the constant factor of two is
+     * irrelevant.
+     *
+     * @param polygon The polygon.
+     * @return Twice the unsigned enclosed area.
+     */
+    private static long ringArea(@Nonnull final MapPolygon polygon)
+    {
+        long sum = 0;
+        final List<BlockPos> points = polygon.getPoints();
+        BlockPos a = points.get(points.size() - 1);
+        for (final BlockPos b : points)
+        {
+            sum += (long) (b.getX() - a.getX()) * (b.getZ() + a.getZ());
+            a = b;
+        }
+        return Math.abs(sum);
     }
 
     /**

--- a/common/src/test/java/journeymap/api/v2/client/util/PolygonHelperTest.java
+++ b/common/src/test/java/journeymap/api/v2/client/util/PolygonHelperTest.java
@@ -134,6 +134,33 @@ class PolygonHelperTest
         assertTrue(expected.equals(reunion(grouped)), "dropping the orphan leaves the hull's fill intact");
     }
 
+    /**
+     * A hole that pokes outside every hull (possible only for arbitrary input, not for the
+     * normalized {@code Area} contours {@code createPolygonFromArea} emits) is contained by no
+     * hull, so it falls back to the first hull it intersects.  This preserves the pre-fix
+     * behavior for {@code classifyAndGroup}'s documented arbitrary-polygon input: the overlapping
+     * quadrant is carved rather than the whole hull rendering solid.
+     */
+    @Test
+    void partiallyOverlappingHoleFallsBackToTheHullItIntersects()
+    {
+        final MapPolygon square = hull(0, 0, 100, 100);
+        final MapPolygon overhangingHole = hole(50, 50, 150, 150);   // only its lower-left quadrant is inside
+
+        final List<MapPolygonWithHoles> grouped =
+                PolygonHelper.classifyAndGroup(Arrays.asList(square, overhangingHole));
+
+        assertEquals(1, grouped.size());
+        assertEquals(1, grouped.get(0).holes.size(),
+                "the partially overlapping hole falls back to the hull it intersects");
+        assertSame(overhangingHole, grouped.get(0).holes.get(0));
+
+        final Area expected = new Area(new Rectangle(0, 0, 100, 100));
+        expected.subtract(new Area(new Rectangle(50, 50, 100, 100)));   // only the overlap is carved
+        assertTrue(expected.equals(reunion(grouped)),
+                "the overlapping quadrant is carved from the hull");
+    }
+
     private static MapPolygon hull(final int minX, final int minZ, final int maxX, final int maxZ)
     {
         // createBlockRect emits counter-clockwise winding, which classifyAndGroup treats as a hull.

--- a/common/src/test/java/journeymap/api/v2/client/util/PolygonHelperTest.java
+++ b/common/src/test/java/journeymap/api/v2/client/util/PolygonHelperTest.java
@@ -1,0 +1,176 @@
+package journeymap.api.v2.client.util;
+
+import journeymap.api.v2.client.model.MapPolygon;
+import journeymap.api.v2.client.model.MapPolygonWithHoles;
+import net.minecraft.core.BlockPos;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Rectangle;
+import java.awt.geom.Area;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PolygonHelperTest
+{
+    private static final int Y = 64;
+
+    /**
+     * The core regression: an island hull sitting inside another hull's hole.  The
+     * hole must be carved from the enclosing square, not from the island whose fill
+     * merely intersects it.  The island hull is fed first so the old
+     * intersection-based pairing (which grabs the first hull it visits) mis-assigns
+     * the hole to the island.
+     */
+    @Test
+    void nestedIslandDoesNotStealTheEnclosingHullsHole()
+    {
+        final MapPolygon square = hull(0, 0, 300, 300);
+        final MapPolygon bigHole = hole(30, 30, 270, 270);
+        final MapPolygon island = hull(125, 125, 175, 175);
+
+        final List<MapPolygonWithHoles> grouped =
+                PolygonHelper.classifyAndGroup(Arrays.asList(island, bigHole, square));
+
+        final MapPolygonWithHoles squareGroup = groupFor(grouped, square);
+        final MapPolygonWithHoles islandGroup = groupFor(grouped, island);
+
+        assertEquals(1, squareGroup.holes.size(), "the hole belongs to the enclosing square");
+        assertSame(bigHole, squareGroup.holes.get(0));
+        assertTrue(islandGroup.holes == null || islandGroup.holes.isEmpty(),
+                "the island encloses no hole");
+
+        // A stolen or dropped hole both break this: every (hull minus its holes) must
+        // re-union to the original area.  Compare via Area.equals(Area) with assertTrue;
+        // assertEquals would bind to Object.equals (identity) and never match.
+        final Area expected = new Area(new Rectangle(0, 0, 300, 300));
+        expected.subtract(new Area(new Rectangle(30, 30, 240, 240)));
+        expected.add(new Area(new Rectangle(125, 125, 50, 50)));
+        assertTrue(expected.equals(reunion(grouped)),
+                "hull-minus-holes must reproduce the input area");
+    }
+
+    /**
+     * A hole enclosed by two nested hulls belongs to the innermost (smallest) one.
+     * The outer hole belongs to the outer hull; the inner hole belongs to the inner
+     * hull, even though the outer hull's filled outline also contains it.
+     */
+    @Test
+    void holeIsPairedWithTheInnermostContainingHull()
+    {
+        final MapPolygon outer = hull(0, 0, 300, 300);
+        final MapPolygon outerHole = hole(30, 30, 270, 270);
+        final MapPolygon inner = hull(60, 60, 240, 240);
+        final MapPolygon innerHole = hole(90, 90, 210, 210);
+
+        final List<MapPolygonWithHoles> grouped =
+                PolygonHelper.classifyAndGroup(Arrays.asList(outer, outerHole, inner, innerHole));
+
+        final MapPolygonWithHoles outerGroup = groupFor(grouped, outer);
+        final MapPolygonWithHoles innerGroup = groupFor(grouped, inner);
+
+        assertEquals(1, outerGroup.holes.size());
+        assertSame(outerHole, outerGroup.holes.get(0));
+        assertEquals(1, innerGroup.holes.size());
+        assertSame(innerHole, innerGroup.holes.get(0));
+
+        final Area expected = new Area(new Rectangle(0, 0, 300, 300));
+        expected.subtract(new Area(new Rectangle(30, 30, 240, 240)));
+        expected.add(new Area(new Rectangle(60, 60, 180, 180)));
+        expected.subtract(new Area(new Rectangle(90, 90, 120, 120)));
+        assertTrue(expected.equals(reunion(grouped)),
+                "hull-minus-holes must reproduce the input area");
+    }
+
+    @Test
+    void plainDonutKeepsItsHole()
+    {
+        final MapPolygon square = hull(0, 0, 100, 100);
+        final MapPolygon donutHole = hole(25, 25, 75, 75);
+
+        final List<MapPolygonWithHoles> grouped =
+                PolygonHelper.classifyAndGroup(Arrays.asList(square, donutHole));
+
+        assertEquals(1, grouped.size());
+        assertEquals(1, grouped.get(0).holes.size());
+        assertSame(donutHole, grouped.get(0).holes.get(0));
+    }
+
+    @Test
+    void severalNonNestedHolesAllGroupWithTheirHull()
+    {
+        final MapPolygon square = hull(0, 0, 100, 100);
+        final MapPolygon holeA = hole(10, 10, 30, 30);
+        final MapPolygon holeB = hole(60, 60, 90, 90);
+
+        final List<MapPolygonWithHoles> grouped =
+                PolygonHelper.classifyAndGroup(Arrays.asList(square, holeA, holeB));
+
+        assertEquals(1, grouped.size());
+        final List<MapPolygon> holes = grouped.get(0).holes;
+        assertEquals(2, holes.size());
+        assertTrue(holes.contains(holeA));
+        assertTrue(holes.contains(holeB));
+    }
+
+    @Test
+    void holeWithNoContainingHullIsDropped()
+    {
+        final MapPolygon square = hull(0, 0, 100, 100);
+        final MapPolygon orphan = hole(200, 200, 250, 250);   // lies entirely outside the hull
+
+        final List<MapPolygonWithHoles> grouped =
+                PolygonHelper.classifyAndGroup(Arrays.asList(square, orphan));
+
+        assertEquals(1, grouped.size());
+        assertTrue(grouped.get(0).holes.isEmpty(), "an unenclosed hole is dropped, not forced onto a hull");
+
+        final Area expected = new Area(new Rectangle(0, 0, 100, 100));
+        assertTrue(expected.equals(reunion(grouped)), "dropping the orphan leaves the hull's fill intact");
+    }
+
+    private static MapPolygon hull(final int minX, final int minZ, final int maxX, final int maxZ)
+    {
+        // createBlockRect emits counter-clockwise winding, which classifyAndGroup treats as a hull.
+        return PolygonHelper.createBlockRect(new BlockPos(minX, Y, minZ), new BlockPos(maxX, Y, maxZ));
+    }
+
+    private static MapPolygon hole(final int minX, final int minZ, final int maxX, final int maxZ)
+    {
+        // Reversing the winding turns the same rectangle into a clockwise hole.
+        final List<BlockPos> points = new ArrayList<>(hull(minX, minZ, maxX, maxZ).getPoints());
+        Collections.reverse(points);
+        return new MapPolygon(points);
+    }
+
+    private static MapPolygonWithHoles groupFor(final List<MapPolygonWithHoles> groups, final MapPolygon hull)
+    {
+        return groups.stream()
+                .filter(group -> group.hull == hull)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no group for the given hull"));
+    }
+
+    private static Area reunion(final List<MapPolygonWithHoles> groups)
+    {
+        final Area total = new Area();
+        for (final MapPolygonWithHoles group : groups)
+        {
+            final Area filled = PolygonHelper.toArea(group.hull);
+            if (group.holes != null)
+            {
+                for (final MapPolygon hole : group.holes)
+                {
+                    filled.subtract(PolygonHelper.toArea(hole));
+                }
+            }
+            total.add(filled);
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
## Symptom

`PolygonHelper.classifyAndGroup` sometimes attaches a hole to the wrong hull. The
hull that truly owns the hole then renders with no hole carved, so its fill covers a
region that was supposed to be empty. When two mods draw adjacent filled tones (one
showing through the other's hole), the mis-paired hull's fill floods solid over the
neighboring tone.

## Root cause

The grouping paired a hole with the **first hull whose filled outline merely
intersected it**, then removed the hole from the pool:

```java
final Area intersection = new Area(hullArea);   // hullArea = toArea(hull), filled solid
intersection.intersect(holeArea);
if (!intersection.isEmpty()) { hullHoles.add(hole); iterator.remove(); }
```

`toArea(hull)` fills the hull ignoring nesting, so "intersects" is far too weak a
test. It breaks whenever a hull is nested inside another hull's hole (an island
sitting inside a hole): both the outer hull and the inner island have filled areas
that overlap the hole between them, so whichever hull the loop visits first claims it.
The pairing is therefore order-dependent, and when the inner island wins it is handed
a hole larger than itself (island minus hole renders as nothing) while the outer hull
is left with no hole and fills solid over the region that should have been carved out.

## Reproduction (nested island-in-hole)

```java
Area a = new Area(new Rectangle(0, 0, 300, 300));       // outer square (hull)
a.subtract(new Area(new Rectangle(30, 30, 240, 240)));  // cut a big rectangular hole
a.add(new Area(new Rectangle(125, 125, 50, 50)));       // island sitting inside the hole
```

The contours are the square (hull), the big rectangle (a hole), and the small
rectangle (an island hull). Correct output: the big hole belongs to the **square**,
and the island has no holes. On the old code the hole is order-dependently grabbed by
the island, the square keeps no hole, and the square's fill covers the region that
should have stayed empty.

(The test builds this topology with rectangles rather than ellipses on purpose:
`createPolygonFromArea` only extracts `SEG_MOVETO`/`SEG_LINETO` segments, so an
ellipse's curved contour would be dropped. Rectilinear contours also match JourneyMap's
real usage, which unions chunk squares.)

## Fix

Pair each hole with the **innermost hull that actually contains it**:

- Containment, not intersection: hull H owns hole O only if O lies entirely inside H
  (`O` minus `H` is empty). An island's fill intersects a hole it does not own, so
  intersection is not enough.
- Innermost when several contain it: containing hulls are nested, so rank candidates by
  the unsigned shoelace area of the hull ring and pick the smallest that contains the
  hole. This also makes the result independent of contour order.
- A hole belongs to exactly one hull; a hole left with no containing hull (malformed
  input) is dropped rather than forced onto an unrelated hull.

`isHole`, `toArea`, and `createPolygonFromArea`'s contour extraction are unchanged;
only the grouping logic changed.

## Tests

Adds `common/src/test/java/journeymap/api/v2/client/util/PolygonHelperTest.java`:

- `nestedIslandDoesNotStealTheEnclosingHullsHole` reproduces the bug (fails on the old
  code, passes on the fix).
- `holeIsPairedWithTheInnermostContainingHull` covers a hole enclosed by two nested
  hulls.
- `holeWithNoContainingHullIsDropped` pins the drop path for an unenclosed hole.
- `plainDonutKeepsItsHole` and `severalNonNestedHolesAllGroupWithTheirHull` guard the
  common cases.

Each test also asserts the invariant that re-unioning every (hull minus its holes)
reproduces the input `Area`, which catches both a stolen and a dropped hole.
`./gradlew :common:test` passes, including the pre-existing tests.

## Branch

Based on `1.21.1_2.0.0`, the repository's default branch. The same change applies to the sibling per-Minecraft-version branches; happy to retarget or port it if you would prefer a different base.